### PR TITLE
Creating a Custom AuthenticationProvider

### DIFF
--- a/java/security-demo-two/src/main/java/com/security/config/CustomAuthenticationProvider.java
+++ b/java/security-demo-two/src/main/java/com/security/config/CustomAuthenticationProvider.java
@@ -1,0 +1,43 @@
+package com.security.config;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+
+    private final PasswordEncoder passwordEncoder;
+
+    public CustomAuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        final String username = authentication.getName();
+        final String password = authentication.getCredentials().toString();
+        final UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+
+
+        if (this.passwordEncoder.matches(password, userDetails.getPassword()))
+            return new UsernamePasswordAuthenticationToken(username, password, userDetails.getAuthorities());
+
+        throw new BadCredentialsException("Something went wrong with authentication");
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+
+}

--- a/java/security-demo-two/src/main/resources/application.properties
+++ b/java/security-demo-two/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 server.port=8080
 
-logging.level.org.springframework.security=DEBUG
-logging.level.org.springframework.security.web.FilterChainProxy=DEBUG
+logging.level.org.springframework.security=TRACE
+logging.level.org.springframework.security.web.FilterChainProxy=TRACE


### PR DESCRIPTION
O método `doFilterInternal()` do `BasicAuthenticationFilter` inicia o processo de autenticação ea primeira coisa a ser feita é obter o tipo de credencial que o usuário forneceu.

Para obter a credencial do usuário use-se o método `convert()` de `BasicAuthenticationConverter` que busca os dados nos headers da requisição. Após essa chamada, algumas outras verificações são feitas e o método `authenticate()` do `ProviderManager` é invocado.

A classe `ProviderManager` itera sobre os `AuthenticationProviders`  disponíveis na aplicação. Antes que a autenticação ocorra, o método `support()` da classe que implementa a interface `AuthenticationProvider`.

Se o resultado de `support()` for false um comando `continue` é executado e o programa sairá do laço e uma exceção será lançada.